### PR TITLE
Bug : fuzzy_match_teams 함수 unpack 오류 해결

### DIFF
--- a/src/cleaning/generate_cleaned_data.py
+++ b/src/cleaning/generate_cleaned_data.py
@@ -60,7 +60,7 @@ def generate_cleaned_data(cfg: Dict) -> None:
     
     fbref_teams = set(fbref_df[fbref_cfg['target_columns'][0]].unique()) | set(fbref_df[fbref_cfg['target_columns'][1]].unique())
     tr_teams = set(tr_df[tr_cfg['source_columns']])
-    team_mapping = fuzzy_match_teams(source=tr_teams, target=fbref_teams, start_threshold=80, step=20)
+    team_mapping, _ = fuzzy_match_teams(source=tr_teams, target=fbref_teams, start_threshold=80, step=20)
 
     tr_df[tr_cfg['source_columns']] = tr_df[tr_cfg['source_columns']].replace(team_mapping)
 


### PR DESCRIPTION
# 오류 해결

fuzzy_match_teams 함수에서 반환값이 (mapping, remaining) 두 개의 값으로 구성되는데,
기존 코드에서 단일 값만 받아 팀명을 replace하지 못하는 문제 발생

→ unpacking을 사용하여 (mapping, _) 형태로 수정하여 문제 해결

예:
    mapping = fuzzy_match_teams(...)  ❌ 잘못된 사용
    mapping, _ = fuzzy_match_teams(...)  ✅ 정상 동작

# 이슈 번호
- Resolved : #4